### PR TITLE
Add Host header for virtual servers

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -32,6 +32,12 @@ func New(base *url.URL) func(http.ResponseWriter, *http.Request) {
 	proxy := httputil.NewSingleHostReverseProxy(base)
 	proxy.ModifyResponse = modifyResponse
 
+	director := proxy.Director
+	proxy.Director = func(r *http.Request) {
+		director(r)
+		r.Host = base.Host
+	}
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Debug().Msg("handling proxy")
 		proxy.ServeHTTP(w, r)


### PR DESCRIPTION
For virtual servers that require a Host header (such as Akamai or CloudFront): https://groups.google.com/g/golang-nuts/c/1ZWCqrs_Oiw/m/tZecP70bQssJ.